### PR TITLE
Add note clarifying lack of temporal data

### DIFF
--- a/data-agents/README.md
+++ b/data-agents/README.md
@@ -19,3 +19,5 @@ python load_public_cases.py
 ```
 
 The script writes `public_cases.csv` in this folder for easy inspection. Modify the script or add new ones to experiment with forecasting ideas and other hypotheses.
+
+For a short explanation of why the dataset is **not** a time series and how to validate that assumption, see [../docs/temporal_validation_summary.md](../docs/temporal_validation_summary.md).

--- a/docs/temporal_validation_summary.md
+++ b/docs/temporal_validation_summary.md
@@ -1,0 +1,23 @@
+# Temporal Structure Validation Summary
+
+This note summarizes how to check whether the reimbursement dataset has any meaningful time component.
+It draws on the instructions from `AGENTS.md`, `TASKS.md`, and the linear workflow in
+`data-agents/FORECAST_DOC_VALIDATION.md`.
+
+## Steps
+
+1. Run the data loader:
+   ```bash
+   python data-agents/load_public_cases.py
+   ```
+   This creates `public_cases.csv` for easier inspection.
+2. Look for date, timestamp, or submission-order fields in the CSV.
+   The public data only includes `trip_duration_days`, `miles_traveled`,
+   and `total_receipts_amount`.
+3. Because no time-based fields exist, shuffling the rows does **not**
+   change the interpretation. Therefore there is no temporal structure
+to model, and the usual forecasting assumptions (stationarity, seasonality,
+long history) do not apply.
+
+Treat the reimbursement logic as a deterministic rule-based system. Use
+`eval.sh` to refine your algorithm rather than forecasting metrics.


### PR DESCRIPTION
## Summary
- document why the reimbursement data is not a time series
- cross-link note from data-agents README

## Testing
- `./eval.sh` *(fails: run.sh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844de047cf88320a4f895956d888c5b