### PR TITLE
Remove codex stubs from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The system takes three inputs:
 
 ## Getting Started
 
-codex/create-run.sh-usage-guide-markdown
 For a walkthrough of how to use `run.sh` along with the evaluation scripts, see
 [docs/run_sh_usage.md](docs/run_sh_usage.md).
 

--- a/data-agents/EDA_FINDINGS.md
+++ b/data-agents/EDA_FINDINGS.md
@@ -1,29 +1,16 @@
 # EDA Findings
 
-gfr814-codex/perform-exploratory-data-analysis-on-historical-data
 This document summarizes observations from `notebooks/01_EDA.ipynb`, which explores `public_cases.json`.
 
 ## Summary statistics
 
 The loader script normalizes the dataset into `public_cases.csv`. Basic statistics provide averages and spreads for trip duration, miles traveled, total receipts, and the expected reimbursement.
-=======
-This document summarizes the key observations from `notebooks/01_EDA.ipynb`, which explores `public_cases.json`.
-
-## Summary statistics
-
-Using the loader script, the dataset of 1000 public cases was normalized into `public_cases.csv`. Basic statistics show mean and median values for trip duration, miles traveled and total receipts, along with the expected reimbursement.
-
 
 ## Key patterns
 
 - **Five-day bonus:** Trips lasting exactly five days tend to reimburse slightly more than nearby durations.
 - **Mileage tapering:** Reimbursement growth slows once mileage exceeds ~100 miles.
-gfr814-codex/perform-exploratory-data-analysis-on-historical-data
 - **Receipts range:** Higher reimbursements cluster around total receipts of $600–$800 (about $100–$120 per day).
 - **Duration effect:** Mean reimbursement by trip duration shows a moderate upward trend with some bumps.
 
 These patterns match the interview hints. `FORECAST_DOC_VALIDATION.md` explains why we treat the data as a deterministic rule set rather than a forecasting problem.
-=======
-- **Receipts range:** Higher reimbursements cluster around total receipts of $600–$800, or about $100–$120 per day.
-
-These patterns are consistent with the hints in `interviews-details.md` and can guide future modeling efforts.

--- a/docs/run_sh_usage.md
+++ b/docs/run_sh_usage.md
@@ -1,4 +1,3 @@
-codex/create-run.sh-usage-guide-markdown
 # Using `run.sh`
 
 Follow these steps to implement and test your reimbursement script:
@@ -31,29 +30,3 @@ Follow these steps to implement and test your reimbursement script:
      ```
 
 These results will be used for the final scoring of your solution.
-=======
-# `run.sh` Quick Start
-
-1. Copy the template:
-   ```bash
-   cp run.sh.template run.sh
-   chmod +x run.sh
-   ```
-
-2. Edit `run.sh` or delegate to another script. It must accept three parameters:
-   ```bash
-   ./run.sh <trip_duration_days> <miles_traveled> <total_receipts_amount>
-   ```
-   The script should print only the reimbursement amount (no extra text).
-
-3. Test your implementation:
-   ```bash
-   ./eval.sh
-   ```
-   This compares your output against `public_cases.json`.
-
-4. Generate results for submission:
-   ```bash
-   ./generate_results.sh
-   ```
-   This creates `private_results.txt` for the submission form.


### PR DESCRIPTION
## Summary
- purge placeholder references from README
- clean the run.sh usage guide
- tidy EDA findings

## Testing
- `grep -n codex README.md docs/run_sh_usage.md data-agents/EDA_FINDINGS.md`
- `grep -n ==== README.md docs/run_sh_usage.md data-agents/EDA_FINDINGS.md`


------
https://chatgpt.com/codex/tasks/task_e_6844e0f30fe48320b67e2d4e9f33cff1