### PR TITLE
Implement small receipt penalties with diminishing returns

### DIFF
--- a/docs/receipt_rules_summary.md
+++ b/docs/receipt_rules_summary.md
@@ -1,0 +1,9 @@
+# Receipt Handling Insights
+
+The interviews reveal several quirks about how the legacy reimbursement system treats receipt totals:
+
+- **Small receipts are penalized** – Employees noticed that submitting tiny amounts, especially under $50, can reduce the reimbursement below the base per diem.
+- **Mid-range receipts get the best return** – Totals between roughly $600 and $800 yield the highest payout. Higher amounts provide diminishing additional reimbursement.
+- **Rounding bonus** – Receipt totals ending in `.49` or `.99` cents often trigger a small bonus due to a rounding bug.
+
+These behaviors informed the heuristics in `run.sh` where we apply a penalty multiplier below $50, taper the reimbursement above $600, and add a $10 bonus when the total ends in `.49` or `.99`.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Reimbursement calculation with simple heuristics
+DAYS=$1
+MILES=$2
+RECEIPTS=$3
+
+# Base per diem
+REIM=$(echo "$DAYS * 80" | bc)
+if [ "$DAYS" -eq 5 ]; then
+  REIM=$(echo "$REIM + 40" | bc)
+fi
+
+# Mileage taper
+if (( $(echo "$MILES <= 100" | bc) )); then
+  MILE_PAY=$(echo "$MILES * 0.6" | bc)
+else
+  MILE_PAY=$(echo "100 * 0.6 + ($MILES - 100) * 0.4" | bc)
+fi
+REIM=$(echo "$REIM + $MILE_PAY" | bc)
+
+# Receipt component
+if (( $(echo "$RECEIPTS < 50" | bc) )); then
+  REC_PART=$(echo "$RECEIPTS * 0.7" | bc)
+elif (( $(echo "$RECEIPTS <= 600" | bc) )); then
+  REC_PART=$(echo "$RECEIPTS * 0.8" | bc)
+elif (( $(echo "$RECEIPTS <= 800" | bc) )); then
+  REC_PART=$(echo "600 * 0.8 + ($RECEIPTS - 600) * 0.5" | bc)
+else
+  REC_PART=$(echo "600 * 0.8 + 200 * 0.5 + ($RECEIPTS - 800) * 0.3" | bc)
+fi
+REIM=$(echo "$REIM + $REC_PART" | bc)
+
+# Bonus for receipts ending .49 or .99
+FRAC=$(printf "%.2f" "$RECEIPTS")
+if [[ "$FRAC" =~ \.49$ || "$FRAC" =~ \.99$ ]]; then
+  REIM=$(echo "$REIM + 10" | bc)
+fi
+
+printf "%.2f" "$REIM"


### PR DESCRIPTION
## Summary
- create `run.sh` from template
- implement per diem and mileage logic with diminishing receipt returns and bonuses for `.49`/`.99`
- document the receipt rounding quirks in a new note

## Testing
- `python setup.py` *(fails: Jupyter command not found)*
- `python data-agents/load_public_cases.py`
- `./eval.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844e4acbaa083208c83f727bb357f37