### PR TITLE
Add starter notebook and evaluation utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The system takes three inputs:
 
 For a walkthrough of how to use `run.sh` along with the evaluation scripts, see
 [docs/run_sh_usage.md](docs/run_sh_usage.md).
+You can also open `notebooks/00_starter.ipynb` for a quick demonstration. That
+notebook relies on helper functions in `scripts/eval_utils.py` to call
+`eval.sh` and visualize the mileage and receipt distributions.
 
 1. **Analyze the data**: 
    - Look at `public_cases.json` to understand patterns

--- a/notebooks/00_starter.ipynb
+++ b/notebooks/00_starter.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Starter Notebook\n",
+    "This notebook loads `public_cases.json`, calls `eval.sh`, and plots mileage and receipt distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from scripts.eval_utils import run_eval, plot_histograms\n",
+    "\n",
+    "with open(Path('public_cases.json')) as f:\n",
+    "    data = json.load(f)\n",
+    "df = pd.json_normalize(data)\n",
+    "df.columns = [c.replace('input.', '') for c in df.columns]\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plot_histograms(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(run_eval())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/eval_utils.py
+++ b/scripts/eval_utils.py
@@ -1,0 +1,28 @@
+import subprocess
+from typing import Any
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def run_eval() -> str:
+    """Run ./eval.sh and return its stdout."""
+    result = subprocess.run(["./eval.sh"], capture_output=True, text=True)
+    return result.stdout
+
+
+def plot_histograms(df: pd.DataFrame) -> Any:
+    """Plot basic histograms for mileage and receipts."""
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    df["miles_traveled"].hist(ax=axes[0], bins=30, color="skyblue", edgecolor="black")
+    axes[0].set_title("Miles Traveled")
+    axes[0].set_xlabel("Miles")
+    axes[0].set_ylabel("Count")
+
+    df["total_receipts_amount"].hist(ax=axes[1], bins=30, color="salmon", edgecolor="black")
+    axes[1].set_title("Total Receipts")
+    axes[1].set_xlabel("Amount ($)")
+    axes[1].set_ylabel("Count")
+
+    plt.tight_layout()
+    return axes
+


### PR DESCRIPTION
## Summary
- add a starter Jupyter notebook showing how to load the dataset, plot histograms, and call `eval.sh`
- provide a `scripts/eval_utils.py` helper with `run_eval` and `plot_histograms`
- document these helper tools in the README

## Testing
- `python -m py_compile scripts/eval_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68459787c8208320af8938abb3110202