### PR TITLE
Add statistical validation notebook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This repository contains everything you need to reverse engineer the legacy reim
 - Do **not** modify `eval.sh` or the data files.
 
 ## 5. Iterate with Notebooks
-- Create notebooks (e.g. `01_EDA.ipynb`, `02_Heuristics.ipynb`, `03_MachineLearning.ipynb`, `04_Hybrid.ipynb`) to explore data and experiment with algorithms. Each notebook can call `eval.sh` via `subprocess` for feedback.
+- Create notebooks (e.g. `01_EDA.ipynb`, `02_Heuristics.ipynb`, `03_MachineLearning.ipynb`, `04_Hybrid.ipynb`, `05_statistical_validation.ipynb`) to explore data and experiment with algorithms. Each notebook can call `eval.sh` via `subprocess` for feedback.
 
 ## 6. Generate Final Results
 - When satisfied, run `./generate_results.sh` to produce `private_results.txt` for submission (see `README.md` lines 53–56 and `TASKS.md` lines 19–22).
@@ -42,6 +42,8 @@ Stick to this workflow and you will be able to test multiple ideas quickly witho
 - Benchmark a Random Forest regressor and inspect feature importances.
 - Cluster residuals from the test set to spot unmodeled patterns.
 - Incorporate the tuned parameters into `run.sh` before final evaluation.
+
+See `notebooks/05_statistical_validation.ipynb` for a worked example of these validation steps.
 
 To add rigor after you build a working script, split the public data into
 train and test sets and measure your rules statistically:

--- a/notebooks/05_statistical_validation.ipynb
+++ b/notebooks/05_statistical_validation.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e1070f5b",
+   "metadata": {},
+   "source": [
+    "# Statistical Validation\n",
+    "This notebook demonstrates an 80/20 train/test split of `public_cases.json`, computes MAE, MAPE, WAPE and RMSE, runs t-tests/ANOVA on interview heuristics and performs a simple grid search for bonus and penalty values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a5b61ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, pandas as pd, numpy as np\n",
+    "from pathlib import Path\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_absolute_error, mean_squared_error\n",
+    "from scipy import stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb157ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "with open('public_cases.json') as f:\n",
+    "    cases = json.load(f)\n",
+    "records = []\n",
+    "for c in cases:\n",
+    "    rec = c['input'].copy()\n",
+    "    rec['expected_output'] = c['expected_output']\n",
+    "    records.append(rec)\n",
+    "df = pd.DataFrame(records)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dbc55a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train/test split\n",
+    "train_df, test_df = train_test_split(df, test_size=0.2, random_state=42)\n",
+    "len(train_df), len(test_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c0829a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple heuristic-based predictor\n",
+    "def predict_row(row, five_day_bonus=50, low_receipt_penalty=0.8):\n",
+    "    base = row['trip_duration_days'] * 100\n",
+    "    if row['trip_duration_days'] == 5:\n",
+    "        base += five_day_bonus\n",
+    "    miles = row['miles_traveled']\n",
+    "    if miles <= 100:\n",
+    "        mileage = miles * 0.6\n",
+    "    else:\n",
+    "        mileage = 100 * 0.6 + (miles - 100) * 0.4\n",
+    "    receipts = row['total_receipts_amount']\n",
+    "    if receipts < 50:\n",
+    "        receipts_component = receipts * low_receipt_penalty\n",
+    "    elif receipts <= 800:\n",
+    "        receipts_component = receipts * 0.8\n",
+    "    else:\n",
+    "        receipts_component = 800 * 0.8 + (receipts - 800) * 0.5\n",
+    "    if str(receipts).endswith('0.49') or str(receipts).endswith('0.99'):\n",
+    "        receipts_component += 10\n",
+    "    if 180 <= miles / row['trip_duration_days'] <= 220:\n",
+    "        mileage += 30\n",
+    "    return base + mileage + receipts_component\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a344eeb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def apply_predict(df, **params):\n",
+    "    return df.apply(predict_row, axis=1, **params)\n",
+    "\n",
+    "train_pred = apply_predict(train_df)\n",
+    "test_pred = apply_predict(test_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c81eb0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mape(y_true, y_pred):\n",
+    "    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100\n",
+    "\n",
+    "def wape(y_true, y_pred):\n",
+    "    return np.sum(np.abs(y_true - y_pred)) / np.sum(np.abs(y_true)) * 100\n",
+    "\n",
+    "def rmse(y_true, y_pred):\n",
+    "    return mean_squared_error(y_true, y_pred, squared=False)\n",
+    "\n",
+    "def evaluate(df, pred):\n",
+    "    y_true = df['expected_output']\n",
+    "    metrics = {\n",
+    "        'MAE': mean_absolute_error(y_true, pred),\n",
+    "        'MAPE': mape(y_true, pred),\n",
+    "        'WAPE': wape(y_true, pred),\n",
+    "        'RMSE': rmse(y_true, pred)\n",
+    "    }\n",
+    "    return metrics\n",
+    "\n",
+    "train_metrics = evaluate(train_df, train_pred)\n",
+    "test_metrics = evaluate(test_df, test_pred)\n",
+    "train_metrics, test_metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b76ecf20",
+   "metadata": {},
+   "source": [
+    "## T-tests and ANOVA\n",
+    "We now test some interview-based heuristics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64956e6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Five-day bonus\n",
+    "per_diem = train_df['expected_output'] / train_df['trip_duration_days']\n",
+    "five_day = per_diem[train_df['trip_duration_days'] == 5]\n",
+    "other = per_diem[train_df['trip_duration_days'].isin([4,6])]\n",
+    "t_stat, p = stats.ttest_ind(five_day, other, equal_var=False)\n",
+    "print('Five-day bonus t-test p-value:', p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cf135f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Efficiency bonus\n",
+    "train_df['miles_per_day'] = train_df['miles_traveled'] / train_df['trip_duration_days']\n",
+    "band = train_df[(train_df['miles_per_day']>=180) & (train_df['miles_per_day']<=220)]\n",
+    "non_band = train_df[(train_df['miles_per_day']<180) | (train_df['miles_per_day']>220)]\n",
+    "stat, p = stats.ttest_ind(band['expected_output'], non_band['expected_output'], equal_var=False)\n",
+    "print('Efficiency bonus t-test p-value:', p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7f9f808",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Receipt buckets ANOVA\n",
+    "train_df['receipt_bucket'] = pd.cut(train_df['total_receipts_amount'], [0,50,800,3000])\n",
+    "groups = [group['expected_output'] for _, group in train_df.groupby('receipt_bucket')]\n",
+    "stat, p = stats.f_oneway(*groups)\n",
+    "print('Receipt bucket ANOVA p-value:', p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffc2af0d",
+   "metadata": {},
+   "source": [
+    "## Grid search\n",
+    "We search over a few values for the five-day bonus and low-receipt penalty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bc93c94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best = None\n",
+    "for bonus in range(0,151,25):\n",
+    "    for penalty in np.linspace(0.7,1.0,4):\n",
+    "        pred = apply_predict(train_df, five_day_bonus=bonus, low_receipt_penalty=penalty)\n",
+    "        mae = mean_absolute_error(train_df['expected_output'], pred)\n",
+    "        if not best or mae < best['mae']:\n",
+    "            best = {'bonus':bonus, 'penalty':penalty, 'mae':mae}\n",
+    "print('Best params', best)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- include `05_statistical_validation.ipynb` showing data split, metrics, testing and grid search
- reference new notebook in `AGENTS.md`

## Testing
- `./eval.sh` *(fails: run.sh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845978e19b88320966c832999547166