### PR TITLE
Add workflow overview doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,4 @@ The prior discussion recommended repeatedly testing hypotheses drawn from the bu
 4. Keep adjusting your algorithm based on these metrics until improvements plateau.
 
 This cycle of hypothesis and measurement should reveal the deterministic logic behind the legacy system.
+See [docs/workflow_overview.md](docs/workflow_overview.md) for a concise summary of these steps.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Key hints from **[INTERVIEWS.md §Lisa from Accounting](INTERVIEWS.md#lisa-from-
 
 For a walkthrough of how to use `run.sh` along with the evaluation scripts, see
 [docs/run_sh_usage.md](docs/run_sh_usage.md).
+For a high-level overview of the entire workflow, read
+[docs/workflow_overview.md](docs/workflow_overview.md).
 You can also open `notebooks/00_starter.ipynb` for a quick demonstration. That
 notebook relies on helper functions in `scripts/eval_utils.py` to call
 `eval.sh` and visualize the mileage and receipt distributions.

--- a/docs/workflow_overview.md
+++ b/docs/workflow_overview.md
@@ -1,0 +1,14 @@
+# Workflow Overview
+
+This guide summarizes the recommended steps for replicating the legacy reimbursement logic.
+
+1. **Validate that the dataset is not a forecasting problem**  
+   See [temporal_validation_summary.md](temporal_validation_summary.md) for how to confirm there is no meaningful time component.
+2. **Translate interview clues into rules**  
+   Use the hints in [../INTERVIEWS.md](../INTERVIEWS.md) to craft heuristics such as daily rates, mileage tiers and receipt rounding effects.
+3. **Run the evaluation script repeatedly**  
+   After each change to `run.sh`, run `./eval.sh` (or `scripts/log_eval.sh`) to measure accuracy on the public cases.
+4. **Apply statistical validation and tuning (optional)**  
+   Follow [statistical_validation_modeling.md](statistical_validation_modeling.md) to test rules and optimize parameters if desired.
+5. **Generate `private_results.txt`**  
+   When satisfied, run `./generate_results.sh` to produce the file used for your submission.


### PR DESCRIPTION
## Summary
- document the overall workflow from validation to submission
- link new overview from the README
- reference the new file in AGENTS.md

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845995ebea08320a3b1166a78ad8c9e