### PR TITLE
Add workflow overview document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This repository contains everything you need to reverse engineer the legacy reim
 - Run `./eval.sh` to test against the 1,000 public cases (per `README.md` lines 50–52 and 74–80).
 - Inspect the summary and error messages to refine your algorithm.
 - Do **not** modify `eval.sh` or the data files.
+- See [docs/workflow_overview.md](docs/workflow_overview.md) for a concise summary of the entire process.
 
 ## 5. Iterate with Notebooks
 - Create notebooks (e.g. `01_EDA.ipynb`, `02_Heuristics.ipynb`, `03_MachineLearning.ipynb`, `04_Hybrid.ipynb`) to explore data and experiment with algorithms. Each notebook can call `eval.sh` via `subprocess` for feedback.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ For a walkthrough of how to use `run.sh` along with the evaluation scripts, see
 You can also open `notebooks/00_starter.ipynb` for a quick demonstration. That
 notebook relies on helper functions in `scripts/eval_utils.py` to call
 `eval.sh` and visualize the mileage and receipt distributions.
+For a short overview of the entire workflow, see
+[docs/workflow_overview.md](docs/workflow_overview.md).
 
 1. **Analyze the data**: 
    - Look at `public_cases.json` to understand patterns

--- a/docs/workflow_overview.md
+++ b/docs/workflow_overview.md
@@ -1,0 +1,16 @@
+# Workflow Overview
+
+This guide summarizes the recommended cycle for reverse engineering the legacy reimbursement logic.
+
+1. **Verify it is not a forecasting problem**
+   - Follow the steps in [temporal_validation_summary.md](temporal_validation_summary.md) to confirm the dataset has no meaningful time component.
+2. **Translate interview clues into rules**
+   - Use the hints in `INTERVIEWS.md` and any notebook analysis to craft heuristic rules.
+3. **Run the evaluation scripts repeatedly**
+   - Execute `./eval.sh` (or `scripts/log_eval.sh` if you want to save logs) after each change and inspect the output.
+4. **Apply statistical validation and tuning** *(optional)*
+   - If you want additional rigor, split the public data into train and test sets and follow techniques from `docs/statistical_validation_modeling.md`.
+5. **Generate final results**
+   - Once the score stabilizes, run `./generate_results.sh` to produce `private_results.txt` for submission.
+
+This high-level workflow keeps the focus on deterministic rules and quick feedback.


### PR DESCRIPTION
## Summary
- outline a short workflow for iterating on `run.sh`
- link the overview from the main guide and agent instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845992ceefc8320994ce7d97d4e7cf9