### PR TITLE
Add evaluation logging script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This repository contains everything you need to reverse engineer the legacy reim
 - Run `./eval.sh` to test against the 1,000 public cases (per `README.md` lines 50–52 and 74–80).
 - Inspect the summary and error messages to refine your algorithm.
 - Do **not** modify `eval.sh` or the data files.
+- Use `./scripts/log_eval.sh` to automatically append results with a timestamp to `eval_history.csv`.
 
 ## 5. Iterate with Notebooks
 - Create notebooks (e.g. `01_EDA.ipynb`, `02_Heuristics.ipynb`, `03_MachineLearning.ipynb`, `04_Hybrid.ipynb`) to explore data and experiment with algorithms. Each notebook can call `eval.sh` via `subprocess` for feedback.
@@ -91,7 +92,7 @@ the random‑forest benchmark.
 The prior discussion recommended repeatedly testing hypotheses drawn from the business context. Use the guidance in `FORECAST_DOC_VALIDATION.md` to structure this process:
 1. Confirm that the data is not a forecasting problem (lines 1‑9).
 2. Form rules from interviews—e.g., receipt thresholds, mileage bonuses, five‑day trip boosts.
-3. After each change, run `./eval.sh` and note the exact and close match counts as well as the average error.
+3. After each change, run `./scripts/log_eval.sh` so the timestamped metrics are stored in `eval_history.csv`.
 4. Keep adjusting your algorithm based on these metrics until improvements plateau.
 
 This cycle of hypothesis and measurement should reveal the deterministic logic behind the legacy system.

--- a/scripts/log_eval.sh
+++ b/scripts/log_eval.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Determine repository root based on script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+# Run evaluation and capture output
+output=$(./eval.sh)
+
+# Display output to user
+echo "$output"
+
+# Extract metrics using grep and parameter expansion
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+total_cases=$(echo "$output" | grep -oP 'Total test cases: \K[0-9]+' || true)
+successful_runs=$(echo "$output" | grep -oP 'Successful runs: \K[0-9]+' || true)
+exact_matches=$(echo "$output" | grep -oP 'Exact matches.*: \K[0-9]+' || true)
+close_matches=$(echo "$output" | grep -oP 'Close matches.*: \K[0-9]+' || true)
+avg_error=$(echo "$output" | grep -oP 'Average error: \$\K[0-9.]+' || true)
+score=$(echo "$output" | grep -oP 'Your Score: \K[0-9.]+' || true)
+
+# Initialize CSV with header if it doesn't exist
+if [ ! -f eval_history.csv ]; then
+    echo "timestamp,total_cases,successful_runs,exact_matches,close_matches,avg_error,score" > eval_history.csv
+fi
+
+# Append metrics
+echo "$timestamp,$total_cases,$successful_runs,$exact_matches,$close_matches,$avg_error,$score" >> eval_history.csv


### PR DESCRIPTION
## Summary
- create `log_eval.sh` helper to log metrics from `eval.sh`
- guide agents to run this script via `AGENTS.md`

## Testing
- `./scripts/log_eval.sh` *(fails: invalid output format in run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_6845978b0f988320a345dd371f77b198