### PR TITLE
Apply root optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Run `./eval.sh` to test your solution against all 1,000 cases. The script will s
 - **Average error**: Mean absolute difference from expected outputs
 - **Score**: Lower is better (combines accuracy and precision)
 
+For convenience, you can run `./scripts/log_eval.sh` instead. It appends each
+evaluation to `eval_history.csv` with a timestamp so you can track your progress
+over time.
+
 Your submission will be tested against `private_cases.json` which does not include the outputs.
 
 ## Submission

--- a/eval_history.csv
+++ b/eval_history.csv
@@ -1,0 +1,3 @@
+timestamp,total_cases,successful_runs,exact_matches,close_matches,avg_error,score
+2025-06-08 15:18:47,1000,1000,0,4,263.66,26466.00
+2025-06-08 15:20:28,1000,1000,0,4,263.31,26431.00

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Baseline reimbursement algorithm
+# Lightweight reimbursement algorithm without external dependencies
 # Usage: ./run.sh <trip_duration_days> <miles_traveled> <total_receipts_amount>
 
 DAYS="$1"
@@ -13,61 +13,72 @@ if [ -z "$DAYS" ] || [ -z "$MILES" ] || [ -z "$RECEIPTS" ]; then
     exit 0
 fi
 
-# Base per diem
-PER_DIEM=$(echo "scale=2; $DAYS * 100" | bc)
-
-# Five-day bonus
+# convert receipts dollars to integer cents without external tools
+if [[ "$RECEIPTS" == *.* ]]; then
+    INT=${RECEIPTS%.*}
+    DEC=${RECEIPTS#*.}
+    # ensure exactly two decimal digits
+    if [ ${#DEC} -eq 1 ]; then
+        DEC="${DEC}0"
+    else
+        DEC="${DEC:0:2}"
+    fi
+    RECEIPTS_CENTS=$((INT * 100 + DEC))
+else
+    RECEIPTS_CENTS=$((RECEIPTS * 100))
+fi
+# base per diem in cents
+PER_DIEM_CENTS=$((DAYS * 10000))
+# five-day bonus
 if [ "$DAYS" -eq 5 ]; then
-    PER_DIEM=$(echo "scale=2; $PER_DIEM + 75" | bc)
+    PER_DIEM_CENTS=$((PER_DIEM_CENTS + 7500))
 fi
 
-# Mileage reimbursement: 0.50 per mile for first 100 miles, 0.25 thereafter
-if (( $(echo "$MILES <= 100" | bc) )); then
-    MILE_PAY=$(echo "scale=2; $MILES * 0.5" | bc)
+# mileage reimbursement: 50 cents first 100 miles, then 25 cents
+if [ "$MILES" -le 100 ]; then
+    MILE_PAY_CENTS=$((MILES * 50))
 else
-    FIRST=$(echo "scale=2; 100 * 0.5" | bc)
-    REST_MILES=$(echo "$MILES - 100" | bc)
-    REST=$(echo "scale=2; $REST_MILES * 0.25" | bc)
-    MILE_PAY=$(echo "scale=2; $FIRST + $REST" | bc)
+    FIRST=$((100 * 50))
+    REST_MILES=$((MILES - 100))
+    REST=$((REST_MILES * 25))
+    MILE_PAY_CENTS=$((FIRST + REST))
 fi
 
-# Receipt component with diminishing returns
-if (( $(echo "$RECEIPTS < 50" | bc) )); then
-    RECEIPT_PAY=$(echo "scale=2; $RECEIPTS * 0.7" | bc)
-elif (( $(echo "$RECEIPTS <= 600" | bc) )); then
-    RECEIPT_PAY=$(echo "scale=2; $RECEIPTS * 0.8" | bc)
-elif (( $(echo "$RECEIPTS <= 800" | bc) )); then
-    MID=$(echo "scale=2; 600 * 0.8" | bc)
-    REM=$(echo "$RECEIPTS - 600" | bc)
-    RECEIPT_PAY=$(echo "scale=2; $MID + $REM * 0.5" | bc)
+# receipt component
+if [ "$RECEIPTS_CENTS" -lt 5000 ]; then
+    RECEIPT_PAY_CENTS=$((RECEIPTS_CENTS * 70 / 100))
+elif [ "$RECEIPTS_CENTS" -le 60000 ]; then
+    RECEIPT_PAY_CENTS=$((RECEIPTS_CENTS * 80 / 100))
+elif [ "$RECEIPTS_CENTS" -le 80000 ]; then
+    MID=$((60000 * 80 / 100))
+    REM=$((RECEIPTS_CENTS - 60000))
+    RECEIPT_PAY_CENTS=$((MID + REM * 50 / 100))
 else
-    MID=$(echo "scale=2; 600 * 0.8 + 200 * 0.5" | bc)
-    REM=$(echo "$RECEIPTS - 800" | bc)
-    RECEIPT_PAY=$(echo "scale=2; $MID + $REM * 0.3" | bc)
+    MID=$((60000 * 80 / 100 + 20000 * 50 / 100))
+    REM=$((RECEIPTS_CENTS - 80000))
+    RECEIPT_PAY_CENTS=$((MID + REM * 30 / 100))
 fi
 
-TOTAL=$(echo "scale=2; $PER_DIEM + $MILE_PAY + $RECEIPT_PAY" | bc)
+TOTAL_CENTS=$((PER_DIEM_CENTS + MILE_PAY_CENTS + RECEIPT_PAY_CENTS))
 
-# Efficiency bonus for 180-220 miles per day
-AVG_MPD=$(echo "scale=2; $MILES / $DAYS" | bc)
-if (( $(echo "$AVG_MPD >= 180 && $AVG_MPD <= 220" | bc) )); then
-    TOTAL=$(echo "scale=2; $TOTAL + 60" | bc)
+# efficiency bonus for 180-220 miles per day
+if [ $((MILES * 100)) -ge $((180 * DAYS)) ] && [ $((MILES * 100)) -le $((220 * DAYS)) ]; then
+    TOTAL_CENTS=$((TOTAL_CENTS + 6000))
 fi
 
-# Receipt rounding quirk bonus
-CENTS=$(printf "%.2f" "$RECEIPTS" | awk -F'.' '{print $2}')
-if [ "$CENTS" = "49" ] || [ "$CENTS" = "99" ]; then
-    TOTAL=$(echo "scale=2; $TOTAL + 10" | bc)
+# receipt rounding quirk bonus
+CENTS_MOD=$((RECEIPTS_CENTS % 100))
+if [ "$CENTS_MOD" -eq 49 ] || [ "$CENTS_MOD" -eq 99 ]; then
+    TOTAL_CENTS=$((TOTAL_CENTS + 1000))
 fi
 
-# Simulated day-of-week adjustment using a simple hash of the inputs
-HASH=$(( (DAYS + ${MILES%.*}) % 7 ))
+# simulated day-of-week adjustment
+HASH=$(( (DAYS + MILES) % 7 ))
 if [ "$HASH" -eq 2 ]; then
-    # Tuesday boost
-    TOTAL=$(echo "scale=2; $TOTAL * 1.03" | bc)
+    TOTAL_CENTS=$((TOTAL_CENTS * 103 / 100))
 elif [ "$HASH" -eq 5 ]; then
-    # Friday penalty
-    TOTAL=$(echo "scale=2; $TOTAL * 0.97" | bc)
+    TOTAL_CENTS=$((TOTAL_CENTS * 97 / 100))
 fi
 
-printf "%.2f\n" "$TOTAL"
+# output in dollars with two decimals
+printf '%d.%02d\n' $((TOTAL_CENTS / 100)) $((TOTAL_CENTS % 100))


### PR DESCRIPTION
## Summary
- optimize `run.sh` to use built‑in arithmetic instead of `bc`
- log evaluation results to `eval_history.csv`
- update README with instructions for `scripts/log_eval.sh`

## Testing
- `./scripts/log_eval.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845a7a748408320a46e833fd0be6f45