### PR TITLE
Add iteration tracker notebook

### DIFF
--- a/notebooks/iteration_tracker.ipynb
+++ b/notebooks/iteration_tracker.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Iteration Tracker\n",
+    "This notebook creates 20 agent notebooks from a simple template.\n",
+    "Each agent notebook can run `scripts/log_eval.sh` to append results to `eval_history.csv`.\n",
+    "Run the cell below to generate the notebooks in this folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "agent_count = 20\n",
+    "nb_template = {\n",
+    "    'cells': [\n",
+    "        {\n",
+    "            'cell_type': 'markdown',\n",
+    "            'metadata': {},\n",
+    "            'source': [\n",
+    "                '# Agent Notebook\\n',\n",
+    "                'Use `scripts/log_eval.sh` after modifying `run.sh`.']\n",
+    "        },\n",
+    "        {\n",
+    "            'cell_type': 'code',\n",
+    "            'metadata': {},\n",
+    "            'execution_count': null,\n",
+    "            'outputs': [],\n",
+    "            'source': [\n",
+    "                'from scripts.eval_utils import run_eval\\n',\n",
+    "                'print(run_eval())']\n",
+    "        }\n",
+    "    ],\n",
+    "    'metadata': {\n",
+    "        'kernelspec': {\n",
+    "            'display_name': 'Python 3',\n",
+    "            'language': 'python',\n",
+    "            'name': 'python3'\n",
+    "        },\n",
+    "        'language_info': {\n",
+    "            'name': 'python',\n",
+    "            'version': '3.12'\n",
+    "        }\n",
+    "    },\n",
+    "    'nbformat': 4,\n",
+    "    'nbformat_minor': 2\n",
+    "}\n",
+    "\n",
+    "for i in range(agent_count):\n",
+    "    out = Path('notebooks') / f'agent_{i:02d}.ipynb'\n",
+    "    with open(out, 'w') as f:\n",
+    "        json.dump(nb_template, f, indent=2)\n",
+    "print(f'Created {agent_count} notebooks.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "sorted(str(p) for p in Path('notebooks').glob('agent_*.ipynb'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- provide an `iteration_tracker.ipynb` notebook to create 20 agent notebooks for eval logging

## Testing
- `python -m json.tool notebooks/iteration_tracker.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6845a7bcb3908320b2f4bdd2df2c39c2